### PR TITLE
Using new syntax to format urls in templates to comply to Django 1.5. Th...

### DIFF
--- a/labgeeks_horae/templates/schedule_home.html
+++ b/labgeeks_horae/templates/schedule_home.html
@@ -10,7 +10,7 @@
 <div class="normal_box">
     <ul id="schedule_options">
         <li>
-            <a class="schedule_option" href="{% url Schedule-View_Timeperiods %}"><div class="option_title">Timeperiods</div>View timeperiods</a>
+            <a class="schedule_option" href="{% url 'Schedule-View_Timeperiods' %}"><div class="option_title">Timeperiods</div>View timeperiods</a>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
...e new syntax is just surrounding path with quotes

URL syntax changes according to https://docs.djangoproject.com/en/1.5/ref/templates/builtins/#std:templatetag-url
